### PR TITLE
Fix tests

### DIFF
--- a/frontend/src/actions/groups/donate.js
+++ b/frontend/src/actions/groups/donate.js
@@ -12,7 +12,10 @@ export default (id, payment, options={}) => {
     dispatch(request(id, payment));
     return postJSON(url, {payment})
       .then(json => dispatch(success(id, json, options)))
-      .catch(error => dispatch(failure(error)));
+      .catch(error => {
+        dispatch(failure(error));
+        throw new Error(error.message);
+      });
   };
 };
 

--- a/frontend/src/actions/subscriptions/cancel.js
+++ b/frontend/src/actions/subscriptions/cancel.js
@@ -14,7 +14,10 @@ export default (id, token) => {
       }
     })
     .then(() => dispatch(success(id, token)))
-    .catch(error => dispatch(failure(id, token, error)));
+    .catch(error => {
+      dispatch(failure(id, token, error));
+      throw new Error(error.message);
+    });
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "mocha": "^2.4.5",
     "mocha-circleci-reporter": "0.0.1",
     "nightwatch": "^0.8.15",
-    "node-fetch": "^1.5.0",
     "nodemon": "^1.8.1",
     "react-addons-test-utils": "^0.14.0",
     "redux-mock-store": "1.0.2",

--- a/test/unit/actions/groups/donate.js
+++ b/test/unit/actions/groups/donate.js
@@ -48,7 +48,8 @@ describe('groups/donate', () => {
     .catch(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.DONATE_GROUP_REQUEST, id: 1, payment });
-      expect(failure).toEqual({ type: constants.DONATE_GROUP_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/payments/ failed')});
+      expect(failure.type).toEqual(constants.DONATE_GROUP_FAILURE);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1/payments/ failed, reason:');
       done();
     });
   });

--- a/test/unit/actions/groups/donate.js
+++ b/test/unit/actions/groups/donate.js
@@ -45,14 +45,12 @@ describe('groups/donate', () => {
     const store = mockStore({});
 
     store.dispatch(donate(1, payment))
-    .then(() => {
+    .catch(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.DONATE_GROUP_REQUEST, id: 1, payment });
-      expect(failure.type).toEqual(constants.DONATE_GROUP_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/groups/1/payments/ failed, reason: ');
+      expect(failure).toEqual({ type: constants.DONATE_GROUP_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/payments/ failed')});
       done();
-    })
-    .catch(done);
+    });
   });
 
   // it.only('redirects user if the donation is via paypal', (done) => {

--- a/test/unit/actions/groups/fetch_by_id.js
+++ b/test/unit/actions/groups/fetch_by_id.js
@@ -43,7 +43,9 @@ describe('groups/fetch_by_id', () => {
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.GROUP_REQUEST, id: 1 });
-      expect(failure).toEqual({ type: constants.GROUP_FAILURE, id: 1, error: new Error('request to http://localhost:3000/api/groups/1 failed') });
+      expect(failure.type).toEqual(constants.GROUP_FAILURE);
+      expect(failure.id).toEqual(1);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1 failed');
       done();
     })
     .catch(done)

--- a/test/unit/actions/groups/fetch_by_id.js
+++ b/test/unit/actions/groups/fetch_by_id.js
@@ -33,7 +33,6 @@ describe('groups/fetch_by_id', () => {
   });
 
   it('creates GROUP_ERROR when fetching a group fails', (done) => {
-    const id = 1;
     nock(env.API_ROOT)
       .get('/groups/1')
       .replyWithError('');
@@ -43,10 +42,8 @@ describe('groups/fetch_by_id', () => {
     store.dispatch(fetchById(1))
     .then(() => {
       const [request, failure] = store.getActions();
-      expect(request).toEqual({ type: constants.GROUP_REQUEST, id });
-      expect(failure.type).toEqual(constants.GROUP_FAILURE);
-      expect(failure.id).toEqual(id);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/groups/1 failed, reason: ');
+      expect(request).toEqual({ type: constants.GROUP_REQUEST, id: 1 });
+      expect(failure).toEqual({ type: constants.GROUP_FAILURE, id: 1, error: new Error('request to http://localhost:3000/api/groups/1 failed') });
       done();
     })
     .catch(done)

--- a/test/unit/actions/groups/get_leaderboard.js
+++ b/test/unit/actions/groups/get_leaderboard.js
@@ -43,8 +43,7 @@ describe('groups/get_leaderboard', () => {
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.GET_LEADERBOARD_REQUEST});
-      expect(failure.type).toEqual(constants.GET_LEADERBOARD_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/leaderboard failed, reason: ');
+      expect(failure).toEqual({ type: constants.GET_LEADERBOARD_FAILURE, error: new Error('request to http://localhost:3000/api/leaderboard failed') });
       done();
     })
     .catch(done)

--- a/test/unit/actions/groups/get_leaderboard.js
+++ b/test/unit/actions/groups/get_leaderboard.js
@@ -43,7 +43,8 @@ describe('groups/get_leaderboard', () => {
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.GET_LEADERBOARD_REQUEST});
-      expect(failure).toEqual({ type: constants.GET_LEADERBOARD_FAILURE, error: new Error('request to http://localhost:3000/api/leaderboard failed') });
+      expect(failure.type).toEqual(constants.GET_LEADERBOARD_FAILURE);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/leaderboard failed');
       done();
     })
     .catch(done)

--- a/test/unit/actions/subscriptions/cancel.js
+++ b/test/unit/actions/subscriptions/cancel.js
@@ -42,17 +42,13 @@ describe('subscriptions/cancel', () => {
     const store = mockStore({});
 
     store.dispatch(cancelSubscription(id, token))
-    .then(() => {
+    .catch(() => {
       const [request, failure] = store.getActions();
 
       expect(request).toEqual({ type: constants.CANCEL_SUBSCRIPTION_REQUEST, id, token });
-      expect(failure.type).toEqual(constants.CANCEL_SUBSCRIPTION_FAILURE);
-      expect(failure.id).toEqual(id);
-      expect(failure.token).toEqual(token);
-      expect(failure.error.message).toEqual(`request to http://localhost:3000/api/subscriptions/${id}/cancel failed, reason: `);
+      expect(failure).toEqual({ type: constants.CANCEL_SUBSCRIPTION_FAILURE, id, token, error: new Error(`request to http://localhost:3000/api/subscriptions/${id}/cancel failed`) });
       done();
-    })
-    .catch(done);
+    });
   });
 
 });

--- a/test/unit/actions/subscriptions/cancel.js
+++ b/test/unit/actions/subscriptions/cancel.js
@@ -46,7 +46,10 @@ describe('subscriptions/cancel', () => {
       const [request, failure] = store.getActions();
 
       expect(request).toEqual({ type: constants.CANCEL_SUBSCRIPTION_REQUEST, id, token });
-      expect(failure).toEqual({ type: constants.CANCEL_SUBSCRIPTION_FAILURE, id, token, error: new Error(`request to http://localhost:3000/api/subscriptions/${id}/cancel failed`) });
+      expect(failure.type).toEqual(constants.CANCEL_SUBSCRIPTION_FAILURE);
+      expect(failure.id).toEqual(id);
+      expect(failure.token).toEqual(token);
+      expect(failure.error.message).toContain(`request to http://localhost:3000/api/subscriptions/${id}/cancel failed`);
       done();
     });
   });

--- a/test/unit/actions/subscriptions/get.js
+++ b/test/unit/actions/subscriptions/get.js
@@ -42,10 +42,11 @@ describe('subscriptions/get', () => {
 
     store.dispatch(getSubscriptions(token))
       .then(() => {
-        const [request, success] = store.getActions();
+        const [request, failure] = store.getActions();
 
         expect(request).toEqual({ type: constants.GET_SUBSCRIPTIONS_REQUEST, token });
-        expect(success).toEqual({ type: constants.GET_SUBSCRIPTIONS_FAILURE, error: new Error(`request to http://localhost:3000/api/subscriptions failed`) });
+        expect(failure.type).toEqual(constants.GET_SUBSCRIPTIONS_FAILURE);
+        expect(failure.error.message).toContain('request to http://localhost:3000/api/subscriptions failed');
         done();
       })
       .catch(done);

--- a/test/unit/actions/subscriptions/get.js
+++ b/test/unit/actions/subscriptions/get.js
@@ -42,11 +42,10 @@ describe('subscriptions/get', () => {
 
     store.dispatch(getSubscriptions(token))
       .then(() => {
-        const [request, failure] = store.getActions();
+        const [request, success] = store.getActions();
 
         expect(request).toEqual({ type: constants.GET_SUBSCRIPTIONS_REQUEST, token });
-        expect(failure.type).toEqual(constants.GET_SUBSCRIPTIONS_FAILURE);
-        expect(failure.error.message).toEqual(`request to http://localhost:3000/api/subscriptions failed, reason: `);
+        expect(success).toEqual({ type: constants.GET_SUBSCRIPTIONS_FAILURE, error: new Error(`request to http://localhost:3000/api/subscriptions failed`) });
         done();
       })
       .catch(done);

--- a/test/unit/actions/transactions/fetch_by_group.js
+++ b/test/unit/actions/transactions/fetch_by_group.js
@@ -45,7 +45,8 @@ describe('transactions/fetch_by_group actions', () => {
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.TRANSACTIONS_REQUEST, groupid });
-      expect(failure).toEqual({ type: constants.TRANSACTIONS_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/transactions failed') });
+      expect(failure.type).toEqual(constants.TRANSACTIONS_FAILURE);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1/transactions failed');
       done();
     })
     .catch(done)

--- a/test/unit/actions/transactions/fetch_by_group.js
+++ b/test/unit/actions/transactions/fetch_by_group.js
@@ -45,8 +45,7 @@ describe('transactions/fetch_by_group actions', () => {
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.TRANSACTIONS_REQUEST, groupid });
-      expect(failure.type).toEqual(constants.TRANSACTIONS_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/groups/1/transactions failed, reason: ');
+      expect(failure).toEqual({ type: constants.TRANSACTIONS_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/transactions failed') });
       done();
     })
     .catch(done)

--- a/test/unit/actions/transactions/fetch_by_id.js
+++ b/test/unit/actions/transactions/fetch_by_id.js
@@ -60,7 +60,8 @@ describe('transactions/fetch_by_id', () => {
       const [request, failure] = store.getActions();
 
       expect(request).toEqual({ type: constants.TRANSACTION_REQUEST, groupid, transactionid });
-      expect(failure).toEqual({ type: constants.TRANSACTION_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/transactions/2 failed') });
+      expect(failure.type).toEqual(constants.TRANSACTION_FAILURE);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1/transactions/2 failed');
       done();
     })
     .catch(done);

--- a/test/unit/actions/transactions/fetch_by_id.js
+++ b/test/unit/actions/transactions/fetch_by_id.js
@@ -60,8 +60,7 @@ describe('transactions/fetch_by_id', () => {
       const [request, failure] = store.getActions();
 
       expect(request).toEqual({ type: constants.TRANSACTION_REQUEST, groupid, transactionid });
-      expect(failure.type).toEqual(constants.TRANSACTION_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/groups/1/transactions/2 failed, reason: ');
+      expect(failure).toEqual({ type: constants.TRANSACTION_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/transactions/2 failed') });
       done();
     })
     .catch(done);

--- a/test/unit/actions/users/fetch_by_group.js
+++ b/test/unit/actions/users/fetch_by_group.js
@@ -46,7 +46,8 @@ describe('users/fetch_by_group', () => {
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.FETCH_USERS_BY_GROUP_REQUEST, groupid });
-      expect(failure).toEqual({ type: constants.FETCH_USERS_BY_GROUP_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/users failed') });
+      expect(failure.type).toEqual(constants.FETCH_USERS_BY_GROUP_FAILURE);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1/users failed');
       done();
     })
     .catch(done)

--- a/test/unit/actions/users/fetch_by_group.js
+++ b/test/unit/actions/users/fetch_by_group.js
@@ -46,8 +46,7 @@ describe('users/fetch_by_group', () => {
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.FETCH_USERS_BY_GROUP_REQUEST, groupid });
-      expect(failure.type).toEqual(constants.FETCH_USERS_BY_GROUP_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/groups/1/users failed, reason: ');
+      expect(failure).toEqual({ type: constants.FETCH_USERS_BY_GROUP_FAILURE, error: new Error('request to http://localhost:3000/api/groups/1/users failed') });
       done();
     })
     .catch(done)

--- a/test/unit/actions/users/refresh_subscriptions_token.js
+++ b/test/unit/actions/users/refresh_subscriptions_token.js
@@ -41,9 +41,10 @@ describe('users/refresh_subscriptions_token', () => {
 
     store.dispatch(refreshSubscriptionsToken(token))
     .catch(() => {
-      const [request, success] = store.getActions();
+      const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.REFRESH_SUBSCRIPTIONS_TOKEN_REQUEST, token })
-      expect(success).toEqual({ type: constants.REFRESH_SUBSCRIPTIONS_TOKEN_FAILURE, token, error: new Error('request to http://localhost:3000/api/subscriptions/refresh_token failed') })
+      expect(failure.type).toEqual(constants.REFRESH_SUBSCRIPTIONS_TOKEN_FAILURE);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/subscriptions/refresh_token failed');
       done();
     })
     .catch(done);

--- a/test/unit/actions/users/refresh_subscriptions_token.js
+++ b/test/unit/actions/users/refresh_subscriptions_token.js
@@ -41,10 +41,9 @@ describe('users/refresh_subscriptions_token', () => {
 
     store.dispatch(refreshSubscriptionsToken(token))
     .catch(() => {
-      const [request, failure] = store.getActions();
-      expect(request).toEqual({ type: constants.REFRESH_SUBSCRIPTIONS_TOKEN_REQUEST, token });
-      expect(failure.type).toEqual(constants.REFRESH_SUBSCRIPTIONS_TOKEN_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/subscriptions/refresh_token failed, reason: ');
+      const [request, success] = store.getActions();
+      expect(request).toEqual({ type: constants.REFRESH_SUBSCRIPTIONS_TOKEN_REQUEST, token })
+      expect(success).toEqual({ type: constants.REFRESH_SUBSCRIPTIONS_TOKEN_FAILURE, token, error: new Error('request to http://localhost:3000/api/subscriptions/refresh_token failed') })
       done();
     })
     .catch(done);

--- a/test/unit/actions/users/send_new_subscription_token.js
+++ b/test/unit/actions/users/send_new_subscription_token.js
@@ -38,9 +38,11 @@ describe('users/send_new_subscriptions_token', () => {
 
     store.dispatch(sendNewSubscriptionToken(email))
     .catch(() => {
-      const [request, success] = store.getActions();
+      const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.SEND_NEW_SUBSCRIPTIONS_TOKEN_REQUEST, email })
-      expect(success).toEqual({ type: constants.SEND_NEW_SUBSCRIPTIONS_TOKEN_FAILURE, email, error: new Error('request to http://localhost:3000/api/subscriptions/new_token failed') })
+      expect(failure.type).toEqual(constants.SEND_NEW_SUBSCRIPTIONS_TOKEN_FAILURE);
+      expect(failure.email).toEqual(email);
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/subscriptions/new_token failed');
       done();
     })
     .catch(done);

--- a/test/unit/actions/users/send_new_subscription_token.js
+++ b/test/unit/actions/users/send_new_subscription_token.js
@@ -38,10 +38,9 @@ describe('users/send_new_subscriptions_token', () => {
 
     store.dispatch(sendNewSubscriptionToken(email))
     .catch(() => {
-      const [request, failure] = store.getActions();
-      expect(request).toEqual({ type: constants.SEND_NEW_SUBSCRIPTIONS_TOKEN_REQUEST, email });
-      expect(failure.type).toEqual(constants.SEND_NEW_SUBSCRIPTIONS_TOKEN_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/subscriptions/new_token failed, reason: ');
+      const [request, success] = store.getActions();
+      expect(request).toEqual({ type: constants.SEND_NEW_SUBSCRIPTIONS_TOKEN_REQUEST, email })
+      expect(success).toEqual({ type: constants.SEND_NEW_SUBSCRIPTIONS_TOKEN_FAILURE, email, error: new Error('request to http://localhost:3000/api/subscriptions/new_token failed') })
       done();
     })
     .catch(done);

--- a/test/unit/actions/users/update.js
+++ b/test/unit/actions/users/update.js
@@ -22,8 +22,8 @@ describe('users/update', () => {
     store.dispatch(updateUser(userid, attributes))
     .then(() => {
       const [request, success] = store.getActions();
-      expect(request).toEqual({ type: constants.UPDATE_USER_REQUEST, userid, attributes });
-      expect(success).toEqual({ type: constants.UPDATE_USER_SUCCESS, userid, attributes, json: attributes });
+      expect(request).toEqual({ type: constants.UPDATE_USER_REQUEST, userid, attributes })
+      expect(success).toEqual({ type: constants.UPDATE_USER_SUCCESS, userid, attributes, json: attributes })
       done();
     })
     .catch(done);
@@ -39,10 +39,9 @@ describe('users/update', () => {
 
     store.dispatch(updateUser(userid, attributes))
     .catch(() => {
-      const [request, failure] = store.getActions();
-      expect(request).toEqual({ type: constants.UPDATE_USER_REQUEST, userid, attributes });
-      expect(failure.type).toEqual(constants.UPDATE_USER_FAILURE);
-      expect(failure.error.message).toEqual('request to http://localhost:3000/api/users/1 failed, reason: ');
+      const [request, success] = store.getActions();
+      expect(request).toEqual({ type: constants.UPDATE_USER_REQUEST, userid, attributes })
+      expect(success).toEqual({ type: constants.UPDATE_USER_FAILURE, error: new Error('request to http://localhost:3000/api/users/1 failed') })
       done();
     })
     .catch(done);

--- a/test/unit/actions/users/update.js
+++ b/test/unit/actions/users/update.js
@@ -39,9 +39,10 @@ describe('users/update', () => {
 
     store.dispatch(updateUser(userid, attributes))
     .catch(() => {
-      const [request, success] = store.getActions();
+      const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.UPDATE_USER_REQUEST, userid, attributes })
-      expect(success).toEqual({ type: constants.UPDATE_USER_FAILURE, error: new Error('request to http://localhost:3000/api/users/1 failed') })
+      expect(failure.type).toEqual(constants.UPDATE_USER_FAILURE)
+      expect(failure.error.message).toContain('request to http://localhost:3000/api/users/1 failed');
       done();
     })
     .catch(done);


### PR DESCRIPTION
The tests broke in the past because `node-fetch` updated their error message 6 days ago. I use `toContain` instead of `toEqual` to be more flexible from now on.

It's important to throw the error to break the promise chain during a failed donation.