### PR TITLE
Don't bundle unused lodash code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["es2015", "stage-0", "react"],
   "plugins": [
-    "add-module-exports"
+    "add-module-exports",
+    "lodash"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "babel": "^5.8.23",
     "babel-eslint": "^4.1.5",
     "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-lodash": "^2.3.0",
     "chai": "^3.3.0",
     "chai-spies": "^0.7.1",
     "chromedriver": "^2.20.0",


### PR DESCRIPTION
Transforms the imports so that the functions are cherry picked. From [`babel-plugin-lodash`'s README](https://github.com/lodash/babel-plugin-lodash):

Transforms:

```js
import _ from 'lodash';
import { add } from 'lodash/fp';

let add1 = add(1);
_.map([1, 2, 3], add1);
```

roughly to

```js
import _add from 'lodash/fp/add';
import _map from 'lodash/map';

let add1 = _add(1);
_map([1, 2, 3], add1);