### PR TITLE
Uses group.tiers to determine types of backers available

### DIFF
--- a/frontend/src/components/public_group/PublicGroupHero.js
+++ b/frontend/src/components/public_group/PublicGroupHero.js
@@ -8,21 +8,27 @@ export default class PublicGroupHero extends React.Component {
   renderHeroStatistics()
   {
     const { group } = this.props;
-    if (!group.backers.length) return;
-    const backerCount = filterCollection(group.backers, {tier: 'backer'}).length;
-    const sponsorCount = filterCollection(group.backers, {tier: 'sponsor'}).length;
     const yearlyIncome = group.yearlyIncome / 100;
     const formattedYearlyIncome = yearlyIncome && formatCurrency(yearlyIncome, group.currency, { compact: true, precision: 0 });
-    return (
+
+    const tierCountString = group.tiers.slice()
+    .sort((tierA, tierB) => tierA.range[0] - tierB.range[0])
+    .map(tier => {
+      const count = filterCollection(group.backers, {tier: tier.name}).length;
+      return (count) ? `${count} ${count === 1 ? tier.name : `${tier.name}s`}` : '';
+    })
+    .filter(x => x)
+    .join(', ');
+
+    return (tierCountString &&
       <div className='PublicGroupHero-backer-statistics'>
         <div className='PublicGroupHero-backer-count-text'>
-          We have <b>{backerCount}</b> backer{backerCount === 1 ? '': 's'}
-          {sponsorCount > 0 && (<span> and <b>{sponsorCount}</b> sponsor{(sponsorCount === 1) ? '': 's'}</span>) }
+          We have {tierCountString}
           {yearlyIncome > 0 && ' that provide us with a yearly budget of'}
         </div>
         {yearlyIncome > 0 && (
             <div className='PublicGroupHero-backer-yearly-budget'>
-              {formattedYearlyIncome.split('').map((character) => <span className={isNaN(character) ? '-character' : '-digit'}>{character}</span>)}
+              {formattedYearlyIncome.split('').map((character) => <span className={/[^0-9]/.test(character) ? '-character' : '-digit'}>{character}</span>)}
             </div>
           )
         }

--- a/frontend/src/components/public_group/PublicGroupHero.js
+++ b/frontend/src/components/public_group/PublicGroupHero.js
@@ -7,24 +7,41 @@ export default class PublicGroupHero extends React.Component {
 
   renderHeroStatistics()
   {
-    const { group } = this.props;
+    const { group, i18n } = this.props;
     const yearlyIncome = group.yearlyIncome / 100;
     const formattedYearlyIncome = yearlyIncome && formatCurrency(yearlyIncome, group.currency, { compact: true, precision: 0 });
 
-    const tierCountString = group.tiers.slice()
-    .sort((tierA, tierB) => tierA.range[0] - tierB.range[0])
+    let tierCountString;
+    const tierCountStringArray = group.tiers.slice()
+    .sort((tierA, tierB) => tierB.range[0] - tierA.range[0])
     .map(tier => {
       const count = filterCollection(group.backers, {tier: tier.name}).length;
       return (count) ? `${count} ${count === 1 ? tier.name : `${tier.name}s`}` : '';
     })
-    .filter(x => x)
-    .join(', ');
+    .filter(x => x);
+
+    if (tierCountStringArray.length > 1)
+    {
+      if (tierCountStringArray.length > 2)
+      {
+        const lastCountString = tierCountStringArray.pop();
+        tierCountString = `${tierCountStringArray.join(', ')} ${i18n.getString('and')} ${lastCountString}`
+      }
+      else
+      {
+        tierCountString = tierCountStringArray.join(` ${i18n.getString('and')} `);
+      }
+    }
+    else
+    {
+      tierCountString = tierCountStringArray[0];
+    }
 
     return (tierCountString &&
       <div className='PublicGroupHero-backer-statistics'>
         <div className='PublicGroupHero-backer-count-text'>
-          We have {tierCountString}
-          {yearlyIncome > 0 && ' that provide us with a yearly budget of'}
+          {i18n.getString('weHave')} {tierCountString}
+          {yearlyIncome > 0 && ` ${i18n.getString('thatProvideYearlyBudget')}`}
         </div>
         {yearlyIncome > 0 && (
             <div className='PublicGroupHero-backer-yearly-budget'>

--- a/frontend/src/ui/strings.json
+++ b/frontend/src/ui/strings.json
@@ -52,7 +52,10 @@
     "becomeMemberTitle": "Why Become a Member?",
     "becomeMemberText": "With your membership plan, you’ll help us cover all expenses the collective makes in order to keep going. All the funds will be managed responsibly with your help, and everyone can see how and where the funds are being spent!",
     "howWeSpend": "See how we spend it",
-    "donateWithPayPal": "Donate with PayPal"
+    "donateWithPayPal": "Donate with PayPal",
+    "and": "and",
+    "weHave": "We have",
+    "thatProvideYearlyBudget": "that provide us with a yearly budget of"
   },
   "fr": {
     "hostedBy": "Hébergé par",
@@ -107,6 +110,9 @@
     "becomeMemberTitle": "Pourquoi devenir un supporter?",
     "becomeMemberText": "Avec votre contribution, vous nous aidez à couvrir nos dépenses. Tous les fonds sont gérés de manière responsable et en toute transparence. Tout le monde peut voir comment on dépense l'argent récolté.",
     "howWeSpend": "Voir comment on utilise l'argent",
-    "donateWithPayPal": "Payer avec PayPal"
+    "donateWithPayPal": "Payer avec PayPal",
+    "and": "et",
+    "weHave": "Nous avons",
+    "thatProvideYearlyBudget": "qui nous fournissent avec un budget annuel de"
   }
 }


### PR DESCRIPTION
They are sorted ASC by tier.ranges[0]
0 backers of any tier, removes them from being displayed

Fixed bug where if currency had a space, it was treated as a digit by isNaN, using a safer regex test now. https://github.com/OpenCollective/OpenCollective/issues/65