### PR TITLE
add group.slug to PublicGroup element

### DIFF
--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -98,8 +98,10 @@ export class PublicGroup extends Component {
       // shareUrl,
     } = this.props;
 
+    const publicGroupClassName = `PublicGroup ${group.slug}`;
+
     return (
-      <div className='PublicGroup'>
+      <div className={publicGroupClassName}>
         <Notification />
 
         <PublicGroupHero group={group} {...this.props} />


### PR DESCRIPTION
As a temporary solution for the GulpJS project (until https://github.com/OpenCollective/OpenCollective/issues/63 can be implemented), @xdamman and I discussed adding the `group.slug` as a class to the hero and then adding custom CSS based on it.