### PR TITLE
Set fixed height for UserCard name, removed UserPhoto avatar bg

### DIFF
--- a/frontend/src/css/components/UserCard.css
+++ b/frontend/src/css/components/UserCard.css
@@ -8,6 +8,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  min-height: 27px;
 }
 
 .UserCard-name > a {
@@ -24,6 +25,9 @@
 /* sponsor card */
 .UserCard.sponsor {
   width: 17.5rem;
+  .UserPhoto {
+    background: none;
+  }
 }
 
 .UserCard.sponsor > .UserCard-name > a {


### PR DESCRIPTION
When a sponsor didn't add a name .UserCard-name would collapse, a fixed height was used.

A gray rectangle bg from UserPhoto component was removed since it is visible even after an image is set when the UserCard is a sponsor, unlike any other tier where the image would cover the bg.
